### PR TITLE
Updating `rules_go`

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -141,8 +141,8 @@ VERSIONS = {
         "type": "github",
         "org": "bazelbuild",
         "repo": "rules_go",
-        "ref": "v0.22.1",
-        "sha256": "fbf7e1f77f44697c0ddee55e36cc01a092e8097323deb5489f4052f9b6aa4d21",
+        "ref": "v0.21.4",
+        "sha256": "f020c69932754be6316d8df110a748ba5f9e8776a7a988e2fedb3eb7eb38fe58",
     },
     "bazel_gazelle": {
         "type": "github",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -141,8 +141,8 @@ VERSIONS = {
         "type": "github",
         "org": "bazelbuild",
         "repo": "rules_go",
-        "ref": "v0.20.2",
-        "sha256": "c92e9be17b8f5d3a5cd4b0549a92c4835a37388b50f007c9cdec9f4ad7baf1f4",
+        "ref": "v0.22.1",
+        "sha256": "fbf7e1f77f44697c0ddee55e36cc01a092e8097323deb5489f4052f9b6aa4d21",
     },
     "bazel_gazelle": {
         "type": "github",


### PR DESCRIPTION
`rules_go` changed the way they consume Google API. In the 0.20 version stated above, they downloaded the whole repository using `http_archive` (it's a 200~ MB repository). Now they switched to just download the released proto files. Because `grpc_proto_grpc` depends on `rules_go`, it's dramatically changed the bootstrap time (as it no longer download a huge repository).