### PR TITLE
Reproduce the ruby_grpc_compile issue in #67

### DIFF
--- a/example/proto-status/BUILD.bazel
+++ b/example/proto-status/BUILD.bazel
@@ -1,0 +1,9 @@
+proto_library(
+    name = "status_proto",
+    srcs = [
+        "status.proto",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/example/proto-status/status.proto
+++ b/example/proto-status/status.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.Status";
+option java_outer_classname = "StatusProto";
+option objc_class_prefix = "GTR";
+
+package status;
+
+
+// Response code of the Response Status.
+enum ResponseCode {
+  RESPONSE_CODE_INVALID = 0;
+  // These codes matches exact with gRPC status codes.
+  // https://developers.google.com/maps-booking/reference/grpc-api-v2/status_codes
+  RESPONSE_CODE_OK = 1;
+  RESPONSE_CODE_CANCELLED = 2;
+  RESPONSE_CODE_UNKNOWN = 3;
+  RESPONSE_CODE_INVALID_ARGUMENT = 4;
+  RESPONSE_CODE_DEADLINE_EXCEEDED = 5;
+  RESPONSE_CODE_NOT_FOUND = 6;
+  RESPONSE_CODE_ALREADY_EXISTS = 7;
+  RESPONSE_CODE_PERMISSION_DENIED = 8;
+  RESPONSE_CODE_UNAUTHENTICATED = 9;
+  RESPONSE_CODE_RESOURCE_EXHAUSTED = 10;
+  RESPONSE_CODE_FAILED_PRECONDITION = 11;
+  RESPONSE_CODE_ABORTED = 12;
+  RESPONSE_CODE_OUT_OF_RANGE = 13;
+  RESPONSE_CODE_UNIMPLEMENTED = 14;
+  RESPONSE_CODE_INTERNAL = 15;
+  RESPONSE_CODE_UNAVAILABLE = 16;
+  RESPONSE_CODE_DATA_LOSS = 17;
+  // Response code for any unhandled exception on the server.
+  RESPONSE_CODE_UNHANDLED_EXCEPTION = 18;
+  // Custom Response code not present in gRPC status codes.
+  RESPONSE_CODE_INVALID_OBJECT_VERSION = 19;
+}
+
+message Status {
+  ResponseCode response_code = 1;
+}

--- a/example/proto/BUILD.bazel
+++ b/example/proto/BUILD.bazel
@@ -68,6 +68,9 @@ proto_library(
     srcs = [
         "greeter.proto",
     ],
+    deps = [
+        "//example/proto-status:status_proto",
+    ],
     visibility = [
         "//visibility:public",
     ],

--- a/example/proto/greeter.proto
+++ b/example/proto/greeter.proto
@@ -21,6 +21,8 @@ option objc_class_prefix = "GTR";
 
 package greeter;
 
+import "example/proto-status/status.proto";
+
 // The greeting service definition.
 service Greeter {
   // Sends a greeting
@@ -35,4 +37,5 @@ message HelloRequest {
 // The response message containing the greetings
 message HelloReply {
   string message = 1;
+  status.Status status = 2;
 }


### PR DESCRIPTION
_This pull request is not meant to be merged. Instead, I'm filing it as a reproducible example of an issue I encountered when using ruby_grpc_compile._

GitHub issue: #67 

```
λ uname -a
Darwin poseidon 19.4.0 Darwin Kernel Version 19.4.0: Wed Mar  4 22:28:40 PST 2020; root:xnu-6153.101.6~15/RELEASE_X86_64 x86_64

λ bazel version
Build label: 3.1.0-homebrew
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Thu May 14 23:56:31 2020 (1589500591)
Build timestamp: 1589500591
Build timestamp as int: 1589500591

λ bazel build //example/ruby/ruby_grpc_compile:greeter_ruby_grpc
INFO: Analyzed target //example/ruby/ruby_grpc_compile:greeter_ruby_grpc (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: /Users/yl/code/keeptruckin/stories/PLATF-5084/src/github.com/rules-proto-grpc/rules_proto_grpc/example/proto-status/BUILD.bazel:1:1: output 'example/proto-status/status_proto/ruby_grpc_compile_aspect_verb0/example/proto-status/status_services_pb.rb' was not created
ERROR: /Users/yl/code/keeptruckin/stories/PLATF-5084/src/github.com/rules-proto-grpc/rules_proto_grpc/example/proto-status/BUILD.bazel:1:1: not all outputs were created or valid
Target //example/ruby/ruby_grpc_compile:greeter_ruby_grpc failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.167s, Critical Path: 0.04s
INFO: 3 processes: 3 darwin-sandbox.
FAILED: Build did NOT complete successfully


λ ls bazel-out/darwin-fastbuild/bin/example/proto-status/status_proto/ruby_grpc_compile_aspect_verb*/example/proto-status/
bazel-out/darwin-fastbuild/bin/example/proto-status/status_proto/ruby_grpc_compile_aspect_verb0/example/proto-status/:
status_pb.rb

bazel-out/darwin-fastbuild/bin/example/proto-status/status_proto/ruby_grpc_compile_aspect_verb1/example/proto-status/:
status_pb.rb

bazel-out/darwin-fastbuild/bin/example/proto-status/status_proto/ruby_grpc_compile_aspect_verb4/example/proto-status/:
status_pb.rb
```