### PR TITLE
Suppress JSC_WRONG_ARGUMENT_COUNT

### DIFF
--- a/closure/closure_proto_library.bzl
+++ b/closure/closure_proto_library.bzl
@@ -23,6 +23,7 @@ def closure_proto_library(**kwargs):
             "JSC_POSSIBLE_INEXISTENT_PROPERTY",
             "JSC_UNRECOGNIZED_TYPE_ERROR",
             "JSC_TYPE_MISMATCH",
+            "JSC_WRONG_ARGUMENT_COUNT",
         ],
     )
 


### PR DESCRIPTION
jspb.Map.deserializeBinary takes 4 to 6 param but the gen-code sends 7 params.