### PR TITLE
Update grpcio Python Version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-grpcio==1.25.0
-grpclib==0.3.1; python_version > '3'
+grpcio==1.31.0
+grpclib==0.4.0; python_version > '3'
 
 # Workaround for rules_python not parsing METADATA from packages that don't have JSON file
 # These are the requirements for h2, which is required by grpclib


### PR DESCRIPTION
1.31.0 has some exciting stuff in it.  Bump the version used by GRPC rules.