### PR TITLE
pass copts to native objc_library

### DIFF
--- a/objc/objc_proto_library.bzl
+++ b/objc/objc_proto_library.bzl
@@ -14,6 +14,7 @@ def objc_proto_library(**kwargs):
         deps = PROTO_DEPS,
         includes = [name_pb],
         visibility = kwargs.get("visibility"),
+        copts = kwargs.get("copts"),
         tags = kwargs.get("tags"),
     )
 


### PR DESCRIPTION
Specifically, this allows to pass '-fno-objc-arc' to clang, it looks like objective-c code generated from protoc doesn't support ARC.