### PR TITLE
Add TypeScript types output to nodejs_proto_* rules

### DIFF
--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -2,27 +2,34 @@ load("//:plugin.bzl", "proto_plugin")
 
 proto_plugin(
     name = "nodejs_plugin",
-    protoc_plugin_name = "js",
+    exclusions = [
+        "google/protobuf",
+    ],
     options = [
         "import_style=commonjs",
         "binary",
     ],
     outputs = ["{protopath}_pb.js"],
-    exclusions = [
-        "google/protobuf",
-    ],
+    protoc_plugin_name = "js",
     visibility = ["//visibility:public"],
 )
 
 proto_plugin(
     name = "grpc_nodejs_plugin",
-    output_directory = True,
-    tool = "@nodejs_modules//grpc-tools/bin:grpc_tools_node_protoc_plugin",
-    options = [
-        "grpc_js",
-    ],
     exclusions = [
         "google/protobuf",
     ],
+    options = [
+        "grpc_js",
+    ],
+    output_directory = True,
+    tool = "@nodejs_modules//grpc-tools/bin:grpc_tools_node_protoc_plugin",
+    visibility = ["//visibility:public"],
+)
+
+proto_plugin(
+    name = "protoc-gen-ts_plugin",
+    outputs = ["{protopath}_pb.d.ts"],
+    tool = "@nodejs_modules//ts-protoc-gen/bin:protoc-gen-ts",
     visibility = ["//visibility:public"],
 )

--- a/nodejs/nodejs_proto_compile.bzl
+++ b/nodejs/nodejs_proto_compile.bzl
@@ -20,6 +20,7 @@ nodejs_proto_compile_aspect = aspect(
             providers = [ProtoPluginInfo],
             default = [
                 Label("//nodejs:nodejs_plugin"),
+                Label("//nodejs:protoc-gen-ts_plugin"),
             ],
         ),
         _prefix = attr.string(

--- a/nodejs/requirements/package.json
+++ b/nodejs/requirements/package.json
@@ -1,7 +1,8 @@
 {
   "dependencies": {
-    "google-protobuf": "3.13.0",
+    "@grpc/grpc-js": "1.1.7",
+    "google-protobuf": "^3.6.1",
     "grpc-tools": "1.9.1",
-    "@grpc/grpc-js": "1.1.7"
+    "ts-protoc-gen": "^0.14.0"
   }
 }

--- a/nodejs/requirements/yarn.lock
+++ b/nodejs/requirements/yarn.lock
@@ -388,10 +388,10 @@ google-p12-pem@^3.0.0:
   dependencies:
     node-forge "^0.10.0"
 
-google-protobuf@3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.13.0.tgz#909c5983d75dd6101ed57c79e0528d000cdc3251"
-  integrity sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw==
+google-protobuf@^3.6.1:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.14.0.tgz#20373d22046e63831a5110e11a84f713cc43651e"
+  integrity sha512-bwa8dBuMpOxg7COyqkW6muQuvNnWgVN8TX/epDRGW5m0jcrmq2QJyCyiV8ZE2/6LaIIqJtiv9bYokFhfpy/o6w==
 
 grpc-tools@1.9.1:
   version "1.9.1"
@@ -887,6 +887,13 @@ tar@^4.4.2:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
+
+ts-protoc-gen@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/ts-protoc-gen/-/ts-protoc-gen-0.14.0.tgz#a6f4c3fc37d1d449915551c18404fb7e9aa8fef6"
+  integrity sha512-2z6w2HioMCMVNcgNHBcEvudmQfzrn+3BjAlz+xgYZ9L0o8n8UG8WUiTJcbXHFiEg2SU8IltwH2pm1otLoMSKwg==
+  dependencies:
+    google-protobuf "^3.6.1"
 
 util-deprecate@~1.0.1:
   version "1.0.2"

--- a/tools/rulegen/nodejs.go
+++ b/tools/rulegen/nodejs.go
@@ -68,7 +68,7 @@ func makeNode() *Language {
 				Name:             "nodejs_proto_compile",
 				Kind:             "proto",
 				Implementation:   aspectRuleTemplate,
-				Plugins:          []string{"//nodejs:nodejs_plugin"},
+				Plugins:          []string{"//nodejs:nodejs_plugin", "//nodejs:protoc-gen-ts_plugin"},
 				WorkspaceExample: nodeWorkspaceTemplate,
 				BuildExample:     protoCompileExampleTemplate,
 				Doc:              "Generates Node.js protobuf `.js` artifacts",


### PR DESCRIPTION
Makes the nodejs_proto_library rule provide DeclarationInfo so it can be a dependency of a ts_project or ts_library rule