### PR TITLE
Fix imports of .d.ts definitions for JS gRPC rules

### DIFF
--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -42,6 +42,7 @@ proto_plugin(
     empty_template = "empty.template",
     options = [
         "service=grpc-node",
+        "mode=grpc-js",
     ],
     outputs = ["{protopath}_grpc_pb.d.ts"],
     tool = "@npm//ts-protoc-gen/bin:protoc-gen-ts",


### PR DESCRIPTION
The generated `.d.ts` files were importing `grpc` instead of `@grpc/grpc-js` b/c `ts-protoc-gen` was being invoked without the `mode=grpc-js` option.

