### PR TITLE
[ObjC] Properly handle protos with dashes in their filenames.

### DIFF
--- a/internal/common.bzl
+++ b/internal/common.bzl
@@ -71,6 +71,12 @@ def pascal_objc(s):
         (string): The capitalized string.
 
     """
+
+    # It is possible for proto files to be named with dashes.
+    # e.g. company-proto.proto, this ensures the output file names for ObjC
+    # correctly match.
+    s = s.replace("-", "_")
+
     segments = []
     for segment in s.split("_"):
         repl = _objc_upper_segments.get(segment)

--- a/test_workspaces/objc_capitalisation/BUILD.bazel
+++ b/test_workspaces/objc_capitalisation/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
     name = "proto_lib",
     srcs = [
         "demo.proto",
+        "folder/dashes-demo.proto",        
         "folder/nested_demo.proto",
     ],
 )

--- a/test_workspaces/objc_capitalisation/folder/dashes-demo.proto
+++ b/test_workspaces/objc_capitalisation/folder/dashes-demo.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message dashes_demo {
+    bool field = 1;
+}


### PR DESCRIPTION
We have some proto file names that include dashes which is causing issues with the generated code for ObjC versus the output files expected to be produced by `objc_proto_compile`.

Given `my-proto-file.proto` with a message `Book`, `objc_proto_compile` expects the output files to be `MyProtoFile.pbobjc.h` and `MyProtoFile.pbobjc.m`. However the `pascal_objc` method is breaking because it does not account for the dashes and it is outputting `My-proto-file.pbobjc.h` causing `objc_proto_compile` to fail. 

It is slightly beyond our control to rename the `.proto` files.

I do not believe this will affect anything else so this seems like a safe change?