### PR TITLE
Set use_built_in_shell_environment default to True

### DIFF
--- a/internal/plugin.bzl
+++ b/internal/plugin.bzl
@@ -51,7 +51,7 @@ proto_plugin = rule(
         ),
         "use_built_in_shell_environment": attr.bool(
             doc = "Whether the tool should use the built in shell environment or not",
-            default = False,
+            default = True,
         ),
         "protoc_plugin_name": attr.string(
             doc = "The name used for the plugin binary on the protoc command line. Useful for targeting built-in plugins. Uses plugin name when not set",


### PR DESCRIPTION
This is required for a protoc compiled with MinGW, which has a dependency on `C:\msys64\mingw64\bin\libstdc++-6.dll` and thus requires `C:\msys64\mingw64\bin` to be in the PATH.

Fixes #181