### PR TITLE
Add M1 Mac/darwin_arm64 support for `protoc-gen-doc`

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -12,6 +12,7 @@ proto_plugin(
         "QUIRK_DIRECT_MODE",
     ],
     tool = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
@@ -31,6 +32,7 @@ proto_plugin(
         "QUIRK_DIRECT_MODE",
     ],
     tool = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
@@ -50,6 +52,7 @@ proto_plugin(
         "QUIRK_DIRECT_MODE",
     ],
     tool = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
@@ -69,6 +72,7 @@ proto_plugin(
         "QUIRK_DIRECT_MODE",
     ],
     tool = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
@@ -85,6 +89,7 @@ proto_plugin(
     ],
     separate_options_flag = True,
     tool = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
         "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",

--- a/doc/repositories.bzl
+++ b/doc/repositories.bzl
@@ -2,6 +2,7 @@
 
 load(
     "//:repositories.bzl",
+    "protoc_gen_doc_darwin_arm64",
     "protoc_gen_doc_darwin_x86_64",
     "protoc_gen_doc_linux_x86_64",
     "protoc_gen_doc_windows_x86_64",
@@ -10,6 +11,7 @@ load(
 
 def doc_repos(**kwargs):  # buildifier: disable=function-docstring
     rules_proto_grpc_repos(**kwargs)
+    protoc_gen_doc_darwin_arm64(**kwargs)
     protoc_gen_doc_darwin_x86_64(**kwargs)
     protoc_gen_doc_linux_x86_64(**kwargs)
     protoc_gen_doc_windows_x86_64(**kwargs)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -153,6 +153,12 @@ VERSIONS = {
     },
 
     # Doc
+    "protoc_gen_doc_darwin_arm64": {
+        "type": "http",
+        "urls": ["https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_darwin_arm64.tar.gz"],
+        "sha256": "6e8c737d9a67a6a873a3f1d37ed8bb2a0a9996f6dcf6701aa1048c7bd798aaf9",
+        "build_file_content": """exports_files(glob(["protoc-gen-doc*"]))""",
+    },
     "protoc_gen_doc_darwin_x86_64": {
         "type": "http",
         "urls": ["https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_darwin_amd64.tar.gz"],
@@ -554,6 +560,9 @@ def com_github_dcarp_protobuf_d(**kwargs):
 #
 # Doc
 #
+def protoc_gen_doc_darwin_arm64(**kwargs):
+    _generic_dependency("protoc_gen_doc_darwin_arm64", **kwargs)
+
 def protoc_gen_doc_darwin_x86_64(**kwargs):
     _generic_dependency("protoc_gen_doc_darwin_x86_64", **kwargs)
 


### PR DESCRIPTION
For the issue described in #198.

From the upstream 1.5.1 release:

https://github.com/pseudomuto/protoc-gen-doc/releases/tag/v1.5.1

```console
$ sha256sum *.tar.gz
f429e5a5ddd886bfb68265f2f92c1c6a509780b7adcaf7a8b3be943f28e144ba  protoc-gen-doc_1.5.1_darwin_amd64.tar.gz
6e8c737d9a67a6a873a3f1d37ed8bb2a0a9996f6dcf6701aa1048c7bd798aaf9  protoc-gen-doc_1.5.1_darwin_arm64.tar.gz
47cd72b07e6dab3408d686a65d37d3a6ab616da7d8b564b2bd2a2963a72b72fd  protoc-gen-doc_1.5.1_linux_amd64.tar.gz
172e6a191daced8eb31ebcd90d4523a1affa6d07900a89b548421823dda796fe  protoc-gen-doc_1.5.1_linux_arm64.tar.gz
8acf0bf64eda29183b4c6745c3c6a12562fd9a8ab08d61788cf56e6659c66b3b  protoc-gen-doc_1.5.1_windows_amd64.tar.gz
bf8bc651c17e64bfec663192e660655c2bcc415f6dff9e88201d8b07fb23d493  protoc-gen-doc_1.5.1_windows_arm64.tar.gz
```