### PR TITLE
Update buf to v1

### DIFF
--- a/buf/buf.bzl
+++ b/buf/buf.bzl
@@ -83,7 +83,7 @@ def buf_proto_breaking_test_impl(ctx):
         "against_input": ctx.file.against_input.path,
         "limit_to_input_files": True,
         "input_config": {
-            "version": "v1beta1",
+            "version": "v1",
             "breaking": {
                 "use": ctx.attr.use_rules,
                 "except": ctx.attr.except_rules,
@@ -94,7 +94,7 @@ def buf_proto_breaking_test_impl(ctx):
 def buf_proto_lint_test_impl(ctx):
     return buf_apply_impl(ctx, [json.encode({
         "input_config": {
-            "version": "v1beta1",
+            "version": "v1",
             "lint": {
                 "use": ctx.attr.use_rules,
                 "except": ctx.attr.except_rules,


### PR DESCRIPTION
Update buf from version `v1beta1` to `v1, to allow using the latest linting rules.