### PR TITLE
Fix bug with proto `against_input` arguments in `buf_proto_breaking_test`

### DIFF
--- a/buf/buf.bzl
+++ b/buf/buf.bzl
@@ -80,7 +80,7 @@ set -uo pipefail
 
 def buf_proto_breaking_test_impl(ctx):
     return buf_apply_impl(ctx, [json.encode({
-        "against_input": ctx.file.against_input.path,
+        "against_input": ctx.file.against_input.short_path,
         "limit_to_input_files": True,
         "input_config": {
             "version": "v1beta1",


### PR DESCRIPTION
Use `.short_path` instead of `.path`, which fixes a bug in `buf_proto_breaking_test` that caused protos to not be found.

Without this fix, a rule like:
```starlark
    buf_proto_breaking_test(
        name = "my_proto_breaking_test",
        against_input = "@my-repo-main//:my_proto,
        protos = [":my_proto"],
    )
```

Fails with an error like:
```
open bazel-out/k8-fastbuild/bin/external/my-repo-main/my_proto/my_proto-descriptor-set.proto.bin: no such file or directory
```

With this fix, it works as expected.

This allows checking breaking changes against a main branch by including the main branch in the `WORKSPACE` file, e.g.:
```starlark
# Download the main branch, to compare changes e.g. breaking protos.
git_repository(
    name = "my-repo-main",
    branch = "main",
    remote = "https://github.com/my-org/my-repo.git",
)
```
Then referring to rules in it for comparing breaking changes (obviously, rules that don't exist in the main branch will fail this test, so only add the test once the rule exists).