### PR TITLE
make sure destination directory exists when copying output

### DIFF
--- a/internal/compile.bzl
+++ b/internal/compile.bzl
@@ -395,6 +395,9 @@ def proto_compile(ctx, options, extra_protoc_args, extra_protoc_files):
 
             # Add command to copy file to output
             command_input_files.append(file)
+            command_parts.append("mkdir $(dirname '{}')".format(
+                "{}/{}".format(new_dir.path, path),
+            ))
             command_parts.append("cp '{}' '{}'".format(
                 file.path,
                 "{}/{}".format(new_dir.path, path),

--- a/internal/compile.bzl
+++ b/internal/compile.bzl
@@ -395,7 +395,7 @@ def proto_compile(ctx, options, extra_protoc_args, extra_protoc_files):
 
             # Add command to copy file to output
             command_input_files.append(file)
-            command_parts.append("mkdir $(dirname '{}')".format(
+            command_parts.append("mkdir -p $(dirname '{}')".format(
                 "{}/{}".format(new_dir.path, path),
             ))
             command_parts.append("cp '{}' '{}'".format(


### PR DESCRIPTION
Without this patch, the compilation will fail if source file being compiled is inside a directory (not in same directory as the BUILD file)