### PR TITLE
Add support M1 Mac for grpc-web

### DIFF
--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -62,7 +62,8 @@ proto_plugin(
         "{protopath}_grpc_web_pb.d.ts",
     ],
     tool = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": "@grpc_web_plugin_darwin//file",
+        "@bazel_tools//src/conditions:darwin_aarch64": "@grpc_web_plugin_darwin_aarch64//file",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@grpc_web_plugin_darwin_x86_64//file",
         "@bazel_tools//src/conditions:linux_x86_64": "@grpc_web_plugin_linux//file",
         "@bazel_tools//src/conditions:windows": "@grpc_web_plugin_windows//file",
     }),

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -62,7 +62,7 @@ proto_plugin(
         "{protopath}_grpc_web_pb.d.ts",
     ],
     tool = select({
-        "@bazel_tools//src/conditions:darwin_aarch64": "@grpc_web_plugin_darwin_aarch64//file",
+        "@bazel_tools//src/conditions:darwin_arm64": "@grpc_web_plugin_darwin_arm64//file",
         "@bazel_tools//src/conditions:darwin_x86_64": "@grpc_web_plugin_darwin_x86_64//file",
         "@bazel_tools//src/conditions:linux_x86_64": "@grpc_web_plugin_linux//file",
         "@bazel_tools//src/conditions:windows": "@grpc_web_plugin_windows//file",

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -4,7 +4,7 @@ load(
     "//:repositories.bzl",
     "build_bazel_rules_nodejs",
     "com_google_protobuf_javascript",
-    "grpc_web_plugin_darwin_aarch64",
+    "grpc_web_plugin_darwin_arm64",
     "grpc_web_plugin_darwin_x86_64",
     "grpc_web_plugin_linux",
     "grpc_web_plugin_windows",
@@ -15,7 +15,7 @@ def js_repos(**kwargs):  # buildifier: disable=function-docstring
     rules_proto_grpc_repos(**kwargs)
     build_bazel_rules_nodejs(**kwargs)
     com_google_protobuf_javascript(**kwargs)
-    grpc_web_plugin_darwin_aarch64(**kwargs)
+    grpc_web_plugin_darwin_arm64(**kwargs)
     grpc_web_plugin_darwin_x86_64(**kwargs)
     grpc_web_plugin_linux(**kwargs)
     grpc_web_plugin_windows(**kwargs)

--- a/js/repositories.bzl
+++ b/js/repositories.bzl
@@ -4,7 +4,8 @@ load(
     "//:repositories.bzl",
     "build_bazel_rules_nodejs",
     "com_google_protobuf_javascript",
-    "grpc_web_plugin_darwin",
+    "grpc_web_plugin_darwin_aarch64",
+    "grpc_web_plugin_darwin_x86_64",
     "grpc_web_plugin_linux",
     "grpc_web_plugin_windows",
     "rules_proto_grpc_repos",
@@ -14,6 +15,7 @@ def js_repos(**kwargs):  # buildifier: disable=function-docstring
     rules_proto_grpc_repos(**kwargs)
     build_bazel_rules_nodejs(**kwargs)
     com_google_protobuf_javascript(**kwargs)
-    grpc_web_plugin_darwin(**kwargs)
+    grpc_web_plugin_darwin_aarch64(**kwargs)
+    grpc_web_plugin_darwin_x86_64(**kwargs)
     grpc_web_plugin_linux(**kwargs)
     grpc_web_plugin_windows(**kwargs)

--- a/js/requirements/package.json
+++ b/js/requirements/package.json
@@ -3,7 +3,7 @@
     "@grpc/grpc-js": "1.6.7",
     "google-protobuf": "3.21.0",
     "grpc-tools": "1.11.2",
-    "grpc-web": "1.3.1",
+    "grpc-web": "1.4.1",
     "ts-protoc-gen": "0.15.0"
   }
 }

--- a/js/requirements/package.json
+++ b/js/requirements/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.6.7",
     "google-protobuf": "3.21.0",
-    "grpc-tools": "1.11.2",
+    "grpc-tools": "1.11.3",
     "grpc-web": "1.4.1",
     "ts-protoc-gen": "0.15.0"
   }

--- a/js/requirements/yarn.lock
+++ b/js/requirements/yarn.lock
@@ -22,9 +22,9 @@
     yargs "^16.2.0"
 
 "@mapbox/node-pre-gyp@^1.0.5":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz#09a8781a3a036151cdebbe8719d6f8b25d4058bc"
-  integrity sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz#8e6735ccebbb1581e5a7e652244cadc8a844d03c"
+  integrity sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==
   dependencies:
     detect-libc "^2.0.0"
     https-proxy-agent "^5.0.0"
@@ -95,9 +95,9 @@
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "18.7.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.13.tgz#23e6c5168333480d454243378b69e861ab5c011a"
-  integrity sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==
+  version "18.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.2.tgz#c59b7641832531264fda3f1ba610362dc9a7dfc8"
+  integrity sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==
 
 abbrev@1:
   version "1.1.1"
@@ -261,22 +261,27 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-google-protobuf@3.21.0, google-protobuf@^3.15.5:
+google-protobuf@3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.0.tgz#8dfa3fca16218618d373d414d3c1139e28034d6e"
   integrity sha512-byR7MBTK4tZ5PZEb+u5ZTzpt4SfrTxv5682MjPlHN16XeqgZE2/8HOIWeiXe8JKnT9OVbtBGhbq8mtvkK8cd5g==
 
-grpc-tools@1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/grpc-tools/-/grpc-tools-1.11.2.tgz#22d802d40012510ccc6591d11f9c94109ac07aab"
-  integrity sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==
+google-protobuf@^3.15.5:
+  version "3.21.2"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.2.tgz#4580a2bea8bbb291ee579d1fefb14d6fa3070ea4"
+  integrity sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==
+
+grpc-tools@1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/grpc-tools/-/grpc-tools-1.11.3.tgz#8218a86ef994e58bd06330b74033de8d7719ea0d"
+  integrity sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.5"
 
-grpc-web@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/grpc-web/-/grpc-web-1.3.1.tgz#6d8affe75a103790b7ad570824e765a1d6a418e4"
-  integrity sha512-VxyYEAGsatecAFY3xieRDzsuhm92yQBsJD7fd5Z3MY150hZWPwkrUWetzJ0QK5W0uym4+VedPQrei38wk0eIjQ==
+grpc-web@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/grpc-web/-/grpc-web-1.4.1.tgz#dfe80ac3693c5343000757ff65c49cf3f854a899"
+  integrity sha512-rZb/vubTg58iWjytpq/aXDpDaAePuXby7kpQqOgrGkVy4FxM2LPz5vjxAcFhWf7peKvLQDhYFk8f7dvH3cZTlw==
 
 has-unicode@^2.0.1:
   version "2.0.1"
@@ -457,9 +462,9 @@ semver@^6.0.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.3.5:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -227,7 +227,7 @@ VERSIONS = {
         "ref": "a428c58273abad07c66071d9753bc4d1289de426",  # TODO: 3.21.0 broken
         "sha256": "08e8aa6b4f434a5364bdef69cd129792677f8b241cdebfa7c10bb43d618e0e05",
     },
-    "grpc_web_plugin_darwin_aarch64": {
+    "grpc_web_plugin_darwin_arm64": {
         "type": "http_file",  # When updating, also update in package.json and vice-versa
         "urls": ["https://github.com/grpc/grpc-web/releases/download/1.4.1/protoc-gen-grpc-web-1.4.1-darwin-aarch64"],
         "sha256": "b086938a7f1851df924d254c0c820c795ae084ed8fc98af4a17d0e10eec0ce59",
@@ -618,8 +618,8 @@ def build_bazel_rules_nodejs(**kwargs):
 def com_google_protobuf_javascript(**kwargs):
     _generic_dependency("com_google_protobuf_javascript", **kwargs)
 
-def grpc_web_plugin_darwin_aarch64(**kwargs):
-    _generic_dependency("grpc_web_plugin_darwin_aarch64", **kwargs)
+def grpc_web_plugin_darwin_arm64(**kwargs):
+    _generic_dependency("grpc_web_plugin_darwin_arm64", **kwargs)
 
 def grpc_web_plugin_darwin_x86_64(**kwargs):
     _generic_dependency("grpc_web_plugin_darwin_x86_64", **kwargs)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -227,22 +227,28 @@ VERSIONS = {
         "ref": "a428c58273abad07c66071d9753bc4d1289de426",  # TODO: 3.21.0 broken
         "sha256": "08e8aa6b4f434a5364bdef69cd129792677f8b241cdebfa7c10bb43d618e0e05",
     },
-    "grpc_web_plugin_darwin": {
+    "grpc_web_plugin_darwin_aarch64": {
         "type": "http_file",  # When updating, also update in package.json and vice-versa
-        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-darwin-x86_64"],
-        "sha256": "466ffe6d2096a2e09823ad02170a90a3e9f79d24094ec8ddcaf6c6d4e673aa2c",
+        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.4.1/protoc-gen-grpc-web-1.4.1-darwin-aarch64"],
+        "sha256": "b086938a7f1851df924d254c0c820c795ae084ed8fc98af4a17d0e10eec0ce59",
+        "executable": True,
+    },
+    "grpc_web_plugin_darwin_x86_64": {
+        "type": "http_file",  # When updating, also update in package.json and vice-versa
+        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.4.1/protoc-gen-grpc-web-1.4.1-darwin-x86_64"],
+        "sha256": "9839f8a61648c045ad220606b005d930edfa86c02b23e1cde15e4038cc8ad1c3",
         "executable": True,
     },
     "grpc_web_plugin_linux": {
         "type": "http_file",  # When updating, also update in package.json and vice-versa
-        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-linux-x86_64"],
-        "sha256": "12d3cfefb22e077251e6d1fae2aeaafd7a66518898397c667ba69cdd1260e72a",
+        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.4.1/protoc-gen-grpc-web-1.4.1-linux-x86_64"],
+        "sha256": "c67ef7e9a36fbcbf9de275f856633ee2bc492cbe16894eb9325dc78a9c892213",
         "executable": True,
     },
     "grpc_web_plugin_windows": {
         "type": "http_file",  # When updating, also update in package.json and vice-versa
-        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.3.1/protoc-gen-grpc-web-1.3.1-windows-x86_64.exe"],
-        "sha256": "f7f3d3b8ddcc7f0f8e432e744768682c070491fc1dcacb922343ec8f39c0d115",
+        "urls": ["https://github.com/grpc/grpc-web/releases/download/1.4.1/protoc-gen-grpc-web-1.4.1-windows-x86_64.exe"],
+        "sha256": "57c5fb71d8be77e01bd2a95cc2532cd1ab06f6392f501c3e71f225441de304dd",
         "executable": True,
     },
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -618,8 +618,11 @@ def build_bazel_rules_nodejs(**kwargs):
 def com_google_protobuf_javascript(**kwargs):
     _generic_dependency("com_google_protobuf_javascript", **kwargs)
 
-def grpc_web_plugin_darwin(**kwargs):
-    _generic_dependency("grpc_web_plugin_darwin", **kwargs)
+def grpc_web_plugin_darwin_aarch64(**kwargs):
+    _generic_dependency("grpc_web_plugin_darwin_aarch64", **kwargs)
+
+def grpc_web_plugin_darwin_x86_64(**kwargs):
+    _generic_dependency("grpc_web_plugin_darwin_x86_64", **kwargs)
 
 def grpc_web_plugin_linux(**kwargs):
     _generic_dependency("grpc_web_plugin_linux", **kwargs)


### PR DESCRIPTION
* Upgrade `grpc-web` to 1.4.1 and `grpc-tools` to 1.11.3 
* Add explicit support for aarch64/arm64 where needed
* Should fix https://github.com/rules-proto-grpc/rules_proto_grpc/issues/180