### PR TITLE
Rename grpc_ecosystem_grpc_gateway to be consistent with the Go ecosystem

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -177,7 +177,7 @@ load("//grpc-gateway:repositories.bzl", "gateway_repos")
 
 gateway_repos()
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -177,7 +177,7 @@ load("//grpc-gateway:repositories.bzl", "gateway_repos")
 
 gateway_repos()
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/docs/lang/grpc-gateway.rst
+++ b/docs/lang/grpc-gateway.rst
@@ -54,7 +54,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    
@@ -164,7 +164,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    
@@ -272,7 +272,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    

--- a/docs/lang/grpc-gateway.rst
+++ b/docs/lang/grpc-gateway.rst
@@ -54,7 +54,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+   load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    
@@ -164,7 +164,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+   load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    
@@ -272,7 +272,7 @@ Full example project can be found `here <https://github.com/rules-proto-grpc/rul
        version = "1.17.1",
    )
    
-   load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+   load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
    
    go_repositories()
    

--- a/example/grpc-gateway/gateway_grpc_compile/WORKSPACE
+++ b/example/grpc-gateway/gateway_grpc_compile/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/example/grpc-gateway/gateway_grpc_compile/WORKSPACE
+++ b/example/grpc-gateway/gateway_grpc_compile/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/example/grpc-gateway/gateway_grpc_library/WORKSPACE
+++ b/example/grpc-gateway/gateway_grpc_library/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/example/grpc-gateway/gateway_grpc_library/WORKSPACE
+++ b/example/grpc-gateway/gateway_grpc_library/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/example/grpc-gateway/gateway_openapiv2_compile/WORKSPACE
+++ b/example/grpc-gateway/gateway_openapiv2_compile/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/example/grpc-gateway/gateway_openapiv2_compile/WORKSPACE
+++ b/example/grpc-gateway/gateway_openapiv2_compile/WORKSPACE
@@ -33,7 +33,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/grpc-gateway/BUILD.bazel
+++ b/grpc-gateway/BUILD.bazel
@@ -9,7 +9,7 @@ proto_plugin(
     ],
     options = ["paths=source_relative"],
     outputs = ["{protopath}.pb.gw.go"],
-    tool = "@grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway",
+    tool = "@grpc_ecosystem_grpc_gateway_v2//protoc-gen-grpc-gateway",
     visibility = ["//visibility:public"],
 )
 
@@ -23,6 +23,6 @@ proto_plugin(
     quirks = [
         "QUIRK_DIRECT_MODE",
     ],
-    tool = "@grpc_ecosystem_grpc_gateway//protoc-gen-openapiv2",
+    tool = "@grpc_ecosystem_grpc_gateway_v2//protoc-gen-openapiv2",
     visibility = ["//visibility:public"],
 )

--- a/grpc-gateway/BUILD.bazel
+++ b/grpc-gateway/BUILD.bazel
@@ -9,7 +9,7 @@ proto_plugin(
     ],
     options = ["paths=source_relative"],
     outputs = ["{protopath}.pb.gw.go"],
-    tool = "@grpc_ecosystem_grpc_gateway_v2//protoc-gen-grpc-gateway",
+    tool = "@com_github_grpc_ecosystem_grpc_gateway_v2//protoc-gen-grpc-gateway",
     visibility = ["//visibility:public"],
 )
 
@@ -23,6 +23,6 @@ proto_plugin(
     quirks = [
         "QUIRK_DIRECT_MODE",
     ],
-    tool = "@grpc_ecosystem_grpc_gateway_v2//protoc-gen-openapiv2",
+    tool = "@com_github_grpc_ecosystem_grpc_gateway_v2//protoc-gen-openapiv2",
     visibility = ["//visibility:public"],
 )

--- a/grpc-gateway/example/gateway/BUILD.bazel
+++ b/grpc-gateway/example/gateway/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
     deps = [
         "//grpc-gateway/example/api:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@go_googleapis//google/rpc:errdetails_go_proto",
         "@com_github_grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+        "@go_googleapis//google/rpc:errdetails_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
     ],

--- a/grpc-gateway/example/gateway/BUILD.bazel
+++ b/grpc-gateway/example/gateway/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//grpc-gateway/example/api:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@go_googleapis//google/rpc:errdetails_go_proto",
-        "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+        "@com_github_grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
     ],

--- a/grpc-gateway/example/gateway/BUILD.bazel
+++ b/grpc-gateway/example/gateway/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//grpc-gateway/example/api:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@go_googleapis//google/rpc:errdetails_go_proto",
-        "@grpc_ecosystem_grpc_gateway//runtime:go_default_library",
+        "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
     ],

--- a/grpc-gateway/gateway_grpc_library.bzl
+++ b/grpc-gateway/gateway_grpc_library.bzl
@@ -36,7 +36,7 @@ GATEWAY_DEPS = [
     "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_grpc//grpclog:go_default_library",
     "@org_golang_google_grpc//metadata:go_default_library",
-    "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
-    "@grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
+    "@com_github_grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+    "@com_github_grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
     "@go_googleapis//google/api:annotations_go_proto",
 ]

--- a/grpc-gateway/gateway_grpc_library.bzl
+++ b/grpc-gateway/gateway_grpc_library.bzl
@@ -36,7 +36,7 @@ GATEWAY_DEPS = [
     "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_grpc//grpclog:go_default_library",
     "@org_golang_google_grpc//metadata:go_default_library",
-    "@grpc_ecosystem_grpc_gateway//runtime:go_default_library",
-    "@grpc_ecosystem_grpc_gateway//utilities:go_default_library",
+    "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+    "@grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
     "@go_googleapis//google/api:annotations_go_proto",
 ]

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -180,7 +180,7 @@ VERSIONS = {
     },
 
     # grpc-gateway
-    "grpc_ecosystem_grpc_gateway_v2": {
+    "com_github_grpc_ecosystem_grpc_gateway_v2": {
         "type": "github",
         "org": "grpc-ecosystem",
         "repo": "grpc-gateway",
@@ -574,7 +574,7 @@ def bazel_gazelle(**kwargs):
 # gRPC gateway
 #
 def grpc_ecosystem_grpc_gateway(**kwargs):
-    _generic_dependency("grpc_ecosystem_grpc_gateway_v2", **kwargs)
+    _generic_dependency("com_github_grpc_ecosystem_grpc_gateway_v2", **kwargs)
 
 #
 # Java

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -180,7 +180,7 @@ VERSIONS = {
     },
 
     # grpc-gateway
-    "grpc_ecosystem_grpc_gateway": {
+    "grpc_ecosystem_grpc_gateway_v2": {
         "type": "github",
         "org": "grpc-ecosystem",
         "repo": "grpc-gateway",
@@ -574,7 +574,7 @@ def bazel_gazelle(**kwargs):
 # gRPC gateway
 #
 def grpc_ecosystem_grpc_gateway(**kwargs):
-    _generic_dependency("grpc_ecosystem_grpc_gateway", **kwargs)
+    _generic_dependency("grpc_ecosystem_grpc_gateway_v2", **kwargs)
 
 #
 # Java

--- a/test_workspaces/go_fixer/WORKSPACE
+++ b/test_workspaces/go_fixer/WORKSPACE
@@ -37,7 +37,7 @@ load("@rules_proto_grpc//grpc-gateway:repositories.bzl", rules_proto_grpc_gatewa
 
 rules_proto_grpc_gateway_repos()
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/test_workspaces/go_fixer/WORKSPACE
+++ b/test_workspaces/go_fixer/WORKSPACE
@@ -37,7 +37,7 @@ load("@rules_proto_grpc//grpc-gateway:repositories.bzl", rules_proto_grpc_gatewa
 
 rules_proto_grpc_gateway_repos()
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 

--- a/tools/rulegen/grpc_gateway.go
+++ b/tools/rulegen/grpc_gateway.go
@@ -18,7 +18,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
+load("@com_github_grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 
@@ -58,8 +58,8 @@ GATEWAY_DEPS = [
     "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_grpc//grpclog:go_default_library",
     "@org_golang_google_grpc//metadata:go_default_library",
-    "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
-    "@grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
+    "@com_github_grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+    "@com_github_grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
     "@go_googleapis//google/api:annotations_go_proto",
 ]`)
 

--- a/tools/rulegen/grpc_gateway.go
+++ b/tools/rulegen/grpc_gateway.go
@@ -18,7 +18,7 @@ go_register_toolchains(
     version = "1.17.1",
 )
 
-load("@grpc_ecosystem_grpc_gateway//:repositories.bzl", "go_repositories")
+load("@grpc_ecosystem_grpc_gateway_v2//:repositories.bzl", "go_repositories")
 
 go_repositories()
 
@@ -58,8 +58,8 @@ GATEWAY_DEPS = [
     "@org_golang_google_protobuf//proto:go_default_library",
     "@org_golang_google_grpc//grpclog:go_default_library",
     "@org_golang_google_grpc//metadata:go_default_library",
-    "@grpc_ecosystem_grpc_gateway//runtime:go_default_library",
-    "@grpc_ecosystem_grpc_gateway//utilities:go_default_library",
+    "@grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
+    "@grpc_ecosystem_grpc_gateway_v2//utilities:go_default_library",
     "@go_googleapis//google/api:annotations_go_proto",
 ]`)
 


### PR DESCRIPTION
Gazelle & the Go ecosystem expects `grpc_ecosystem_grpc_gateway` to be named `com_github_grpc_ecosystem_grpc_gateway_v2` instead. 

Fixes #238 
Fixes #242 
