### PR TITLE
Add bzl_library build targets.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//internal",
+    ],
+)

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "internal",
+    srcs = [
+        "common.bzl",
+        "compile.bzl",
+        "filter_files.bzl",
+        "plugin.bzl",
+        "protoc.bzl",
+        "providers.bzl",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@rules_proto//proto:defs",
+    ],
+)


### PR DESCRIPTION
The targets seem to be required for using "stardoc_with_diff_test" in rules_ts_proto.