### PR TITLE
Remove grpc sources from runfiles trees

### DIFF
--- a/cpp/cpp_grpc_library.bzl
+++ b/cpp/cpp_grpc_library.bzl
@@ -33,8 +33,9 @@ def cpp_grpc_library(name, **kwargs):  # buildifier: disable=function-docstring
     # Create cpp library
     cc_library(
         name = name,
-        srcs = [name_pb],
+        srcs = [name_pb + "_srcs"],
         deps = GRPC_DEPS + kwargs.get("deps", []),
+        hdrs = [name_pb + "_hdrs"],
         includes = [name_pb],
         alwayslink = kwargs.get("alwayslink"),
         copts = kwargs.get("copts"),


### PR DESCRIPTION
If a C++ binary uses grpc code generated with cpp_grpc_library, the resulting runfiles tree includes the generated grpc sources.

Reproducer here:
https://gist.github.com/william-smith-skydio/e3b630f7cc826ad33f283b8017a88cc7

```bash
> tree bazel-bin/test.runfiles/__main__/
bazel-bin/test.runfiles/__main__/
├── grpc_test_proto_cpp_pb
│   ├── grpc_test.grpc.pb.cc -> ...
│   ├── grpc_test.grpc.pb.h -> ...
│   ├── grpc_test_mock.grpc.pb.h -> ...
│   ├── grpc_test.pb.cc -> ...
│   └── grpc_test.pb.h -> ...
└── test -> ...
```

With this patch applied, I get the expected behavior:

```bash
tree bazel-bin/test.runfiles
bazel-bin/test.runfiles
├── __main__
│   └── test -> ...
└── MANIFEST
```

This issue does not affect cpp_proto_library since that was already using the split srcs/hdrs targets.