### PR TITLE
[Platform Transitions] Fix platform transitions for selecting tools. 

### DIFF
--- a/buf/BUILD.bazel
+++ b/buf/BUILD.bazel
@@ -1,14 +1,30 @@
 load("//:defs.bzl", "proto_plugin")
 
-proto_plugin(
-    name = "breaking_plugin",
-    quirks = ["QUIRK_DIRECT_MODE"],
-    separate_options_flag = True,
-    tool = select({
+# Use an alias to resolve platform transitions and do the select based on the execution platform.
+# Otherwise, if we put the select in the tool, then it selects based on the target platform instead. 
+alias(
+    name = "proto_gen_buf_breaking",
+    actual = select({
         "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_buf_breaking_darwin_arm64//file",
         "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_buf_breaking_darwin_x86_64//file",
         "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_buf_breaking_linux_x86_64//file",
     }),
+)
+
+alias(
+    name = "proto_gen_buf_lint",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_buf_lint_darwin_arm64//file",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_buf_lint_darwin_x86_64//file",
+        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_buf_lint_linux_x86_64//file",
+    }),
+)
+
+proto_plugin(
+    name = "breaking_plugin",
+    quirks = ["QUIRK_DIRECT_MODE"],
+    separate_options_flag = True,
+    tool = ":proto_gen_buf_breaking",
     visibility = ["//visibility:public"],
 )
 
@@ -16,10 +32,6 @@ proto_plugin(
     name = "lint_plugin",
     quirks = ["QUIRK_DIRECT_MODE"],
     separate_options_flag = True,
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_buf_lint_darwin_arm64//file",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_buf_lint_darwin_x86_64//file",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_buf_lint_linux_x86_64//file",
-    }),
+    tool = ":proto_gen_buf_lint",
     visibility = ["//visibility:public"],
 )

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,5 +1,17 @@
 load("//:defs.bzl", "proto_plugin")
 
+# Use an alias to resolve platform transitions and do the select based on the execution platform.
+# Otherwise, if we put the select in the tool, then it selects based on the target platform instead. 
+alias(
+    name = "proto_gen_doc",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
+        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
+        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
+    }),
+)
+
 proto_plugin(
     name = "docbook_plugin",
     out = "{name}.xml",
@@ -11,12 +23,7 @@ proto_plugin(
         "QUIRK_OUT_PASS_ROOT",
         "QUIRK_DIRECT_MODE",
     ],
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
-    }),
+    tool = ":proto_gen_doc",
     visibility = ["//visibility:public"],
 )
 
@@ -31,12 +38,8 @@ proto_plugin(
         "QUIRK_OUT_PASS_ROOT",
         "QUIRK_DIRECT_MODE",
     ],
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
-    }),
+    tool = ":proto_gen_doc",
+
     visibility = ["//visibility:public"],
 )
 
@@ -51,12 +54,8 @@ proto_plugin(
         "QUIRK_OUT_PASS_ROOT",
         "QUIRK_DIRECT_MODE",
     ],
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
-    }),
+    tool = ":proto_gen_doc",
+
     visibility = ["//visibility:public"],
 )
 
@@ -71,12 +70,8 @@ proto_plugin(
         "QUIRK_OUT_PASS_ROOT",
         "QUIRK_DIRECT_MODE",
     ],
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
-    }),
+    tool = ":proto_gen_doc",
+
     visibility = ["//visibility:public"],
 )
 
@@ -88,11 +83,7 @@ proto_plugin(
         "QUIRK_DIRECT_MODE",
     ],
     separate_options_flag = True,
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@protoc_gen_doc_darwin_arm64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@protoc_gen_doc_darwin_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:linux_x86_64": "@protoc_gen_doc_linux_x86_64//:protoc-gen-doc",
-        "@bazel_tools//src/conditions:windows": "@protoc_gen_doc_windows_x86_64//:protoc-gen-doc.exe",
-    }),
+    tool = ":proto_gen_doc",
+
     visibility = ["//visibility:public"],
 )

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -49,6 +49,19 @@ proto_plugin(
     visibility = ["//visibility:public"],
 )
 
+# Use an alias to resolve platform transitions and do the select based on the execution platform.
+# Otherwise, if we put the select in the tool, then it selects based on the target platform instead.
+# This is because there is a platform transition on the tool (from target to execution platform).  
+alias(
+    name = "grpc_web_plugin",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin_arm64": "@grpc_web_plugin_darwin_arm64//file",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@grpc_web_plugin_darwin_x86_64//file",
+        "@bazel_tools//src/conditions:linux_x86_64": "@grpc_web_plugin_linux//file",
+        "@bazel_tools//src/conditions:windows": "@grpc_web_plugin_windows//file",
+    }),
+)
+
 # grpc-web
 proto_plugin(
     name = "grpc_web_js_plugin",
@@ -61,11 +74,6 @@ proto_plugin(
         "{protopath}_grpc_web_pb.js",
         "{protopath}_grpc_web_pb.d.ts",
     ],
-    tool = select({
-        "@bazel_tools//src/conditions:darwin_arm64": "@grpc_web_plugin_darwin_arm64//file",
-        "@bazel_tools//src/conditions:darwin_x86_64": "@grpc_web_plugin_darwin_x86_64//file",
-        "@bazel_tools//src/conditions:linux_x86_64": "@grpc_web_plugin_linux//file",
-        "@bazel_tools//src/conditions:windows": "@grpc_web_plugin_windows//file",
-    }),
+    tool = ":grpc_web_plugin",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I ran into an issue the other day where I have a multi-platform repo and I was compiling code for a different platform (in this case QNX). 

I ran into an issue with the docs compile rule where I would get the following error: 
```
ERROR: /home/jzahn/.cache/bazel/_bazel_jzahn/7bf1254182ebae36d2817c38fe27106c/external/rules_proto_grpc/doc/BUILD.bazel:63:13: configurable attribute "tool" in @rules_proto_grpc//doc:markdown_plugin doesn't match this configuration. Would a default condition help?

Conditions checked:
 @bazel_tools//src/conditions:darwin_arm64
 @bazel_tools//src/conditions:darwin_x86_64
 @bazel_tools//src/conditions:linux_x86_64
 @bazel_tools//src/conditions:windows
 ```
 
 The issue was we were compiling for QNX, but even though the tool is for the execution platform, the select operates on the target platform when selecting the tool. So added an alias buffer rule in between the tool and the select so the select would only operate on the execution platform. That seemed to work, so I implemented the buffer for everywhere where I saw this pattern. 