### PR TITLE
docs: fix missing 'env' at custom_plugins rst doc

### DIFF
--- a/docs/custom_plugins.rst
+++ b/docs/custom_plugins.rst
@@ -124,7 +124,7 @@ API Reference
      - false
      - ``[]``
      - A list of extra command line arguments to pass directly to protoc, not as plugin options
-   * - ``extra_protoc_args``
+   * - ``env``
      - ``string_dict``
      - false
      - ``{}``


### PR DESCRIPTION
As stated in [internal/plugin.bzl doc](
https://github.com/rules-proto-grpc/rules_proto_grpc/blob/c6a88cbc4f977d41af944da072a70f26abe67912/internal/plugin.bzl#L53C10-L53C13),  the text and type is fine but name `extra_protoc_args` is incorrectly duplicated (and `env` is missing).