### PR TITLE
Update GRPC version to 1.57.0

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -7,7 +7,7 @@ load("//internal:common.bzl", "check_bazel_minimum_version")
 MINIMUM_BAZEL_VERSION = "5.3.0"
 ENABLE_VERSION_NAGS = False
 PROTOBUF_VERSION = "21.10"  # When updating, also update protobuf-javascript, JS requirements, JS rulegen in js.go, Ruby requirements and C#/F# requirements
-GRPC_VERSION = "1.54.1"  # When updating, also update grpc hash, grpc-java hash, Go repositories.bzl, Ruby requirements and C#/F# requirements
+GRPC_VERSION = "1.57.0"  # When updating, also update grpc hash, grpc-java hash, Go repositories.bzl, Ruby requirements and C#/F# requirements
 BUF_VERSION = "v1.9.0"
 VERSIONS = {
     # Core
@@ -30,7 +30,7 @@ VERSIONS = {
         "org": "grpc",
         "repo": "grpc",
         "ref": "v{}".format(GRPC_VERSION),
-        "sha256": "79e3ff93f7fa3c8433e2165f2550fa14889fce147c15d9828531cbfc7ad11e01",
+        "sha256": "8393767af531b2d0549a4c26cf8ba1f665b16c16fb6c9238a7755e45444881dd",
     },
     "zlib": {
         "type": "http",
@@ -194,7 +194,7 @@ VERSIONS = {
         "org": "grpc",
         "repo": "grpc-java",
         "ref": "v{}".format(GRPC_VERSION),
-        "sha256": "98c32df8a878cbca5a6799922d28e9df93a4d5607316e0e3f8269a5886d9e429",
+        "sha256": "bfe7112b53973f45adbcfe8b34e0b5458e030cb40178f617c465547a158335bd",
     },
     "rules_jvm_external": {
         "type": "github",


### PR DESCRIPTION
Update GRPC_VERSION to 1.57.0 
1. grpc - https://github.com/grpc/grpc/releases/tag/v1.57.0
2.  grpc_java - https://github.com/grpc/grpc-java/releases/tag/v1.57.0

Blocking issue from the previous version - https://github.com/grpc/grpc-java/issues/9916

