### PR TITLE
rust: Allow all clippy lints for generated code.

### DIFF
--- a/rust/rust_fixer.bzl
+++ b/rust/rust_fixer.bzl
@@ -7,7 +7,7 @@ def _rust_proto_crate_root(ctx):
     lib_rs = ctx.actions.declare_file("%s_lib.rs" % name)
     ctx.actions.write(
         lib_rs,
-        'include!("%s/mod.rs");' % name,
+        '#![allow(clippy::all)]\ninclude!("%s/mod.rs");' % name,
         False,
     )
     return [DefaultInfo(


### PR DESCRIPTION
The lints are generally appropriate for hand-written code, but oftentimes the best solution for generated code violates such guidelines. Typically, therefore, generated code is not subject to such linting.

The most precise way to disable linting for this generated code in a bazel environment is to add `#![allow(clippy::all)]` to the top level of the generated crate. That said, I am not confident that I have found the appropriate place to effect this change. I figured that it would be better with a PR than just the issue 🙂 