### PR TITLE
rust: JSON compliant casing

### DIFF
--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -51,7 +51,6 @@ proto_plugin(
     ],
     options = [
         "no_include",
-        "preserve_proto_field_names",
         "extern_path=.google.protobuf=::pbjson_types",
     ],
     output_directory = True,


### PR DESCRIPTION
Quoting [1]:

> By default proto3 JSON printer should convert the field name to
> lowerCamelCase and use that as the JSON name. An implementation
> may provide an option to use proto field name as the JSON name
> instead.

The serde plugin does this correctly, but when the rules specify the `preserve_proto_field_names` option, two things happen:

1. The generated serde code preserves the proto field names (instead of converting the casing as it should)
2. The user of these bazel rules cannot override the choice

If, instead, rules_proto_grpc avoids specifying this flag, it can be optionally added to the rust_prost_proto_library invocation in user code via `options`:

    options = {
        "//rust:rust_serde_plugin": ["preserve_proto_field_names"],
    },

Thus, the better default is to leave out this flag from rules_proto_grpc and instead allow the user to choose.

[1]: https://protobuf.dev/programming-guides/proto3/#json