### PR TITLE
Only forward nocopts to cc_library if present in kwargs

### DIFF
--- a/cpp/cpp_proto_library.bzl
+++ b/cpp/cpp_proto_library.bzl
@@ -37,19 +37,20 @@ def cpp_proto_library(name, **kwargs):  # buildifier: disable=function-docstring
         deps = PROTO_DEPS + kwargs.get("deps", []),
         hdrs = [name_pb + "_hdrs"],
         includes = [name_pb] if kwargs.get("output_mode", "PREFIXED") == "PREFIXED" else ["."],
-        alwayslink = kwargs.get("alwayslink"),
-        copts = kwargs.get("copts"),
-        defines = kwargs.get("defines"),
-        include_prefix = kwargs.get("include_prefix"),
-        linkopts = kwargs.get("linkopts"),
-        linkstatic = kwargs.get("linkstatic"),
-        local_defines = kwargs.get("local_defines"),
-        nocopts = kwargs.get("nocopts"),
-        strip_include_prefix = kwargs.get("strip_include_prefix"),
         **{
             k: v
             for (k, v) in kwargs.items()
-            if k in bazel_build_rule_common_attrs
+            if k in bazel_build_rule_common_attrs + [
+                "alwayslink",
+                "copts",
+                "defines",
+                "include_prefix",
+                "linkopts",
+                "linkstatic",
+                "local_defines",
+                "nocopts",
+                "strip_include_prefix",
+            ]
         }  # Forward Bazel common args
     )
 


### PR DESCRIPTION
Modifies the cc_library call to only forward arguments if they're present in kwargs. This is vital for bazel 7.0.0 compatibility since the `nocopts` attribute is removed (it's actually been deprecated since 2019 but the documentation was never updated).