### PR TITLE
Avoid using undeclared parameter

### DIFF
--- a/rust/rust_tonic_grpc_library.bzl
+++ b/rust/rust_tonic_grpc_library.bzl
@@ -37,7 +37,6 @@ def rust_tonic_grpc_library(name, **kwargs):  # buildifier: disable=function-doc
     rust_proto_crate_root(
         name = name_root,
         crate_dir = name_fixed,
-        mod_file = kwargs.get("mod_file"),
     )
 
     # Create rust_tonic library


### PR DESCRIPTION
Bazel 7 gives an error for this code.

It seems like a half-implemented feature, where the user is supposed to be able to specify the root filename for the module (typically, and by default, `mod.rs`), but the `mod_file` parameter never gets read. It seems like a bug that somebody may want to fix.

In the meantime we can remove this argument to make the rules work with bazel 7 without changing the semantics.