### PR TITLE
Avoid creating symlinks that point out of output TreeArtifact

### DIFF
--- a/modules/core/internal/compile.bzl
+++ b/modules/core/internal/compile.bzl
@@ -414,7 +414,7 @@ def proto_compile(ctx, options, extra_protoc_args, extra_protoc_files):
         # Build copy command for directory outputs
         # Use cp {}/. rather than {}/* to allow for empty output directories from a plugin (e.g when
         # no service exists, so no files generated)
-        command_parts = ["mkdir -p {} && cp -r {} '{}'".format(
+        command_parts = ["mkdir -p {} && cp -rL {} '{}'".format(
             # We need to be sure that the dirs exist, see:
             # https://github.com/bazelbuild/bazel/issues/6393
             " ".join(["'" + d.path + "'" for d in premerge_dirs]),


### PR DESCRIPTION
`cp -r` copies the _symlinks_, not the destination of symlinks.  This results in
a TreeArtifact with symlinks to content _outside_ the TreeArtifact, which is not
well defined in bazel[^1].  At least bazel 7.1.1's linux-sandbox (bazel
--spawn_strategy=sandboxed on Linux) does not follow the symlinks and destroys
the temporary directory containing the actual files after the action, leaving a
TreeArtifact of dangling symlinks.

`cp -rL` chases the symlinks and creates a TreeArtifact of regular files.  This
has the desired behaviour in all bazel versions/sandboxes.

[^1]: See discussion in https://github.com/bazelbuild/bazel/issues/15454.  It is
unclear whether we _want_ to resolve these symlinks or leave them dangling, and
behaviour varies across bazel versions and execution environment.