### PR TITLE
Fix wrong toolchains label in Custom Plugins document

### DIFF
--- a/docs/custom_plugins.rst
+++ b/docs/custom_plugins.rst
@@ -71,7 +71,7 @@ short, the basic idea is:
                doc = "List of protoc plugins to apply",
            ),
        ),
-       toolchains = [str(Label("@rules_proto_grpc//protoc:toolchain_type"))],
+       toolchains = [str(Label("@rules_proto_grpc//protobuf:toolchain_type"))],
    )
 
 


### PR DESCRIPTION
Version: v4.6.0
In custom plugin, if I defined toolchain attribute as `@rules_proto_grpc//protoc:toolchain_type` in proto compile rule just same as document:

```
# Create compile rule
example_compile = rule(
    implementation = proto_compile_impl,
    attrs = dict(
       ...
    ),
    toolchains = [str(Label("@rules_proto_grpc//protoc:toolchain_type"))],
)
```

It has error when build:
```
(11:16:43) ERROR: /.../BUILD:29:20: While resolving toolchains for target //foo_protoc:foo_proto: com.google.devtools.build.lib.packages.BuildFileNotFoundException: no such package '@rules_proto_grpc//protoc': BUILD file not found in directory 'protoc' of external repository @rules_proto_grpc. Add a BUILD file to a directory to mark it as a package.
```

Replace it to `@rules_proto_grpc//protobuf:toolchain_type` will resolve this problem. And I found there is no folder named `protoc` under the `<bazel_cache_dir>/external/rules_proto_grpc`.

Maybe code of the document is outdated. Please review this pull request, thanks!
