### PR TITLE
Use protobuf-java 4.29.2

### DIFF
--- a/modules/java/MODULE.bazel
+++ b/modules/java/MODULE.bazel
@@ -22,8 +22,8 @@ maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "rules_proto_grpc_java_maven",  # Deconflict
     artifacts = [
-        "com.google.protobuf:protobuf-java:4.27.2",
-        "com.google.protobuf:protobuf-java-util:4.27.2",
+        "com.google.protobuf:protobuf-java:4.29.2",
+        "com.google.protobuf:protobuf-java-util:4.29.2",
         "io.grpc:grpc-api:1.65.0",
         "io.grpc:grpc-netty:1.65.0",
         "io.grpc:grpc-protobuf:1.65.0",


### PR DESCRIPTION
Fixes #392 

All the things I reported in #392 suggested that there was a mismatch between protobuf-java and protoc. [The documentation for protobuf and protobuf-java](https://github.com/protocolbuffers/protobuf/tree/main/java) states:

> Make sure the version number of the runtime matches (or is newer than) the version number of the protoc.

I confirmed that this works by adding the following to my own project and have now succesesfully built `java_proto_library` and `java_grpc_library` that usedon `repeated enum`:

```starlark

# both of these are needed to properly override the rules_proto_grpc_java
bazel_dep(name = "rules_proto_grpc", version = "5.0.1")
git_override(
    module_name = "rules_proto_grpc",
    commit = "fdc3c887479dfe8da152c4863393388da0f40dfa",
    remote = "https://github.com/justtechnologies/rules_proto_grpc",
    strip_prefix = "modules/core",
)
bazel_dep(name = "rules_proto_grpc_java", version = "5.0.1")
git_override(
    module_name = "rules_proto_grpc_java",
    commit = "fdc3c887479dfe8da152c4863393388da0f40dfa",
    remote = "https://github.com/justtechnologies/rules_proto_grpc",
    strip_prefix = "modules/java",
)

```