### PR TITLE
Use `non_arc_srcs` instead of `srcs` for objc_library, since protoc-generated .m files don't use ARC.

### DIFF
--- a/tools/rulegen/objc.go
+++ b/tools/rulegen/objc.go
@@ -30,7 +30,7 @@ var objcProtoLibraryRuleTemplate = mustTemplate(objcLibraryRuleTemplateString + 
     # Create {{ .Lang.Name }} library
     objc_library(
         name = name,
-        srcs = [name_pb + "_srcs"],
+        non_arc_srcs = [name_pb + "_srcs"],
         deps = PROTO_DEPS + kwargs.get("deps", []),
         hdrs = [name_pb + "_hdrs"],
         includes = [name_pb],
@@ -59,7 +59,7 @@ var objcGrpcLibraryRuleTemplate = mustTemplate(objcLibraryRuleTemplateString + `
     # Create {{ .Lang.Name }} library
     objc_library(
         name = name,
-        srcs = [name_pb],
+        non_arc_srcs = [name_pb],
         deps = GRPC_DEPS + kwargs.get("deps", []),
         includes = [name_pb],
         **{


### PR DESCRIPTION
I wasn't sure how to build & run `tools/rulegen` to make the changes to modules/objc/objc_(grpc)_library.bzl files, though I have validated that the if the files are edited directly, this change works for me as expected. I'm happy to run, rebuild, and test if someone can help me out with that.

For the actual ARC change, see the Objective-C protobuf [Building](https://github.com/protocolbuffers/protobuf/blob/main/objectivec/README.md#building) documentation note about ARC: "If the target is using ARC, remember to turn off ARC (-fno-objc-arc) for the .m files.