### PR TITLE
Remove ctx.resolve_tools

### DIFF
--- a/modules/buf/buf.bzl
+++ b/modules/buf/buf.bzl
@@ -68,7 +68,6 @@ set -uo pipefail
             ".",
             short_paths = True,
             extra_options = options,
-            resolve_tools = False,
         )
         all_inputs += cmd_inputs
 

--- a/modules/core/internal/protoc.bzl
+++ b/modules/core/internal/protoc.bzl
@@ -14,7 +14,7 @@ def build_protoc_args(
         extra_options = [],
         extra_protoc_args = [],
         short_paths = False,
-        resolve_tools = True):
+        resolve_tools = None):
     """
     Build the args for a protoc invocation.
 
@@ -38,17 +38,15 @@ def build_protoc_args(
 
     """
 
+    if resolve_tools != None:
+        print("WARNING: build_protoc_args: Ignored legacy resolve_tools argument set to {}".format(resolve_tools))
+
     # Specify path getter
     get_path = _short_path if short_paths else _path
 
     # Build inputs and manifests list
     inputs = []
     input_manifests = []
-
-    if plugin.tool and resolve_tools:
-        plugin_runfiles, plugin_input_manifests = ctx.resolve_tools(tools = [plugin.tool])
-        inputs += plugin_runfiles.to_list()
-        input_manifests += plugin_input_manifests
 
     inputs += plugin.data
 


### PR DESCRIPTION
It already was redundant, I think, because the tool_executable is added here:

https://github.com/rules-proto-grpc/rules_proto_grpc/blob/5dcdc6916261703f9fc5e19620c7bd37bc6410d0/modules/core/internal/compile.bzl#L350

Filled in

https://github.com/rules-proto-grpc/rules_proto_grpc/blob/5dcdc6916261703f9fc5e19620c7bd37bc6410d0/modules/core/internal/plugin.bzl#L11

https://github.com/rules-proto-grpc/rules_proto_grpc/issues/390