### PR TITLE
remove experimental_use_cc_common_link

### DIFF
--- a/modules/core/tools/fixer/BUILD.bazel
+++ b/modules/core/tools/fixer/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy")
 rust_binary(
     name = "fixer",
     srcs = ["main.rs"],
-    experimental_use_cc_common_link = 1,
     visibility = ["//visibility:public"],
 )
 

--- a/modules/core/tools/merger/BUILD.bazel
+++ b/modules/core/tools/merger/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_clippy")
 rust_binary(
     name = "merger",
     srcs = ["main.rs"],
-    experimental_use_cc_common_link = 1,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This seems to cause my build to fail with the following error.

```
ERROR: /home/troy/.cache/bazel/_bazel_troy/f0307b93a4e15de94d1739eb6cc8c44a/external/rules_proto_grpc+/tools/merger/BUILD.bazel:3:12: Linking external/rules_proto_grpc+/tools/merger/merger [for tool] failed: (Exit 1): clang++ failed: error executing CppLink command (from target @@rules_proto_grpc+//tools/merger:merger) 
  (cd /home/troy/.cache/bazel/_bazel_troy/f0307b93a4e15de94d1739eb6cc8c44a/sandbox/linux-sandbox/3000/execroot/_main && \
  exec env - \
    PATH=/bin:/usr/bin:/usr/local/bin \
    PWD=/proc/self/cwd \
  external/+_repo_rules+clang-linux-x86_64/bin/clang++ @bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger-0.params)
# Configuration: 92c8d64696a2cadf5e5c6fc06d3109aebb260204039ff7ecd751f33e86b6d68f
# Execution platform: @@platforms//host:host

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: undefined symbol: __rustc::__rust_dealloc
>>> referenced by alloc.rs:114 (library/alloc/src/alloc.rs:114)
>>>               std-099ea48a26be4ce8.std.da76efc55aba569b-cgu.0.rcgu.o:(core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::hf21d1b8d70abb284) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-099ea48a26be4ce8.a
>>> referenced by merger.119d0e05786ef20f-cgu.0
>>>               bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger.o:(core::ptr::drop_in_place$LT$std..env..Args$GT$::hdd6afb9133edc6f3)
>>> referenced by merger.119d0e05786ef20f-cgu.0
>>>               bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger.o:(core::ptr::drop_in_place$LT$std..env..Args$GT$::hdd6afb9133edc6f3)
>>> referenced 468 more times

ld.lld: error: undefined symbol: __rustc::__rust_no_alloc_shim_is_unstable_v2
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::boxed::Box$LT$T$C$A$GT$::new_uninit_in::hba3af28824c0716c) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::boxed::Box$LT$T$C$A$GT$::new_uninit_in::hc1543ca763b5aee3) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced by merger.119d0e05786ef20f-cgu.0
>>>               bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger.o:(alloc::raw_vec::finish_grow::hf24276ee39ab3082)
>>> referenced 60 more times

ld.lld: error: undefined symbol: __rustc::__rust_alloc
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::boxed::Box$LT$T$C$A$GT$::new_uninit_in::hba3af28824c0716c) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced by merger.119d0e05786ef20f-cgu.0
>>>               bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger.o:(alloc::raw_vec::finish_grow::hf24276ee39ab3082)
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::boxed::Box$LT$T$C$A$GT$::new_uninit_in::hc1543ca763b5aee3) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced 59 more times

ld.lld: error: undefined symbol: __rustc::__rust_realloc
>>> referenced by merger.119d0e05786ef20f-cgu.0
>>>               bazel-out/k8-opt-exec/bin/external/rules_proto_grpc+/tools/merger/merger.o:(alloc::raw_vec::finish_grow::hf24276ee39ab3082)
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::raw_vec::finish_grow::h469e8b4f7c4591fb) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced by alloc.rs:134 (library/alloc/src/alloc.rs:134)
>>>               alloc-f41fc22260701b19.alloc.679dddab44c6194d-cgu.0.rcgu.o:(alloc::raw_vec::finish_grow::ha067b8125b9d82ce) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-f41fc22260701b19.a
>>> referenced 14 more times

ld.lld: error: undefined symbol: __rustc::__rust_alloc_zeroed
>>> referenced by gimli.acabe08ff855beb1-cgu.0
>>>               gimli-de694aa69c98867e.gimli.acabe08ff855beb1-cgu.0.rcgu.o:(alloc::raw_vec::RawVecInner$LT$A$GT$::try_allocate_in::h260dbbb64a41af0a) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-de694aa69c98867e.a
>>> referenced by alloc.rs:177 (library/alloc/src/alloc.rs:177)
>>>               std-099ea48a26be4ce8.std.da76efc55aba569b-cgu.0.rcgu.o:(std::backtrace_rs::symbolize::gimli::stash::Stash::allocate::h925d54d852a8637d) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-099ea48a26be4ce8.a

ld.lld: error: undefined symbol: __rustc::__rust_alloc_error_handler
>>> referenced by alloc.rs:406 (library/alloc/src/alloc.rs:406)
>>>               alloc-f41fc22260701b19.alloc.679dddab44c6194d-cgu.0.rcgu.o:(alloc::alloc::handle_alloc_error::h62b0c67f72f21d9d) in archive bazel-out/k8-opt-exec/bin/external/rules_rust++rust+rust_linux_x86_64__x86_64-unknown-linux-gnu__stable_tools/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-f41fc22260701b19.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
Target //cloud/proto:ts failed to build
INFO: Elapsed time: 2.391s, Critical Path: 0.90s
INFO: 86 processes: 58 action cache hit, 5 disk cache hit, 66 internal, 15 linux-sandbox.
ERROR: Build did NOT complete successfully
```

Removing this fixes the error