### PR TITLE
Propagate .pyi files to PyInfo for type checking support

### DIFF
--- a/modules/python/python_grpc_library.bzl
+++ b/modules/python/python_grpc_library.bzl
@@ -1,6 +1,6 @@
 """Generated definition of python_grpc_library."""
 
-load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "proto_compile_attrs")
+load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "filter_files", "proto_compile_attrs")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//:python_grpc_compile.bzl", "python_grpc_compile")
 
@@ -28,6 +28,17 @@ def python_grpc_library(name, generate_pyi = False, **kwargs):
         }  # Forward args
     )
 
+    # Filter .pyi files when generating pyi to add to pyi_srcs
+    pyi_srcs = []
+    if generate_pyi:
+        name_pyi_files = name_pb + "_pyi_files"
+        filter_files(
+            name = name_pyi_files,
+            target = name_pb,
+            extensions = ["pyi"],
+        )
+        pyi_srcs = [name_pyi_files]
+
     # For other code to import generated code with prefix_path if it's given
     output_mode = kwargs.get("output_mode", "PREFIXED")
     if output_mode == "PREFIXED":
@@ -47,6 +58,7 @@ def python_grpc_library(name, generate_pyi = False, **kwargs):
         deps = GRPC_DEPS + kwargs.get("deps", []),
         data = kwargs.get("data", []),  # See https://github.com/rules-proto-grpc/rules_proto_grpc/issues/257 for use case
         imports = imports,
+        pyi_srcs = pyi_srcs,
         **{
             k: v
             for (k, v) in kwargs.items()

--- a/modules/python/python_grpclib_library.bzl
+++ b/modules/python/python_grpclib_library.bzl
@@ -1,6 +1,6 @@
 """Generated definition of python_grpclib_library."""
 
-load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "proto_compile_attrs")
+load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "filter_files", "proto_compile_attrs")
 load("@rules_proto_grpc_python_pip_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//:python_grpclib_compile.bzl", "python_grpclib_compile")
@@ -19,6 +19,17 @@ def python_grpclib_library(name, generate_pyi = False, **kwargs):
         }  # Forward args
     )
 
+    # Filter .pyi files when generating pyi to add to pyi_srcs
+    pyi_srcs = []
+    if generate_pyi:
+        name_pyi_files = name_pb + "_pyi_files"
+        filter_files(
+            name = name_pyi_files,
+            target = name_pb,
+            extensions = ["pyi"],
+        )
+        pyi_srcs = [name_pyi_files]
+
     # Create python library
     py_library(
         name = name,
@@ -26,6 +37,7 @@ def python_grpclib_library(name, generate_pyi = False, **kwargs):
         deps = GRPCLIB_DEPS + kwargs.get("deps", []),
         data = kwargs.get("data", []),  # See https://github.com/rules-proto-grpc/rules_proto_grpc/issues/257 for use case
         imports = [name_pb],
+        pyi_srcs = pyi_srcs,
         **{
             k: v
             for (k, v) in kwargs.items()

--- a/modules/python/python_proto_library.bzl
+++ b/modules/python/python_proto_library.bzl
@@ -1,6 +1,6 @@
 """Generated definition of python_proto_library."""
 
-load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "proto_compile_attrs")
+load("@rules_proto_grpc//:defs.bzl", "bazel_build_rule_common_attrs", "filter_files", "proto_compile_attrs")
 load("@rules_python//python:defs.bzl", "py_library")
 load("//:python_proto_compile.bzl", "python_proto_compile")
 
@@ -28,6 +28,17 @@ def python_proto_library(name, generate_pyi = False, **kwargs):
         }  # Forward args
     )
 
+    # Filter .pyi files when generating pyi to add to pyi_srcs
+    pyi_srcs = []
+    if generate_pyi:
+        name_pyi_files = name_pb + "_pyi_files"
+        filter_files(
+            name = name_pyi_files,
+            target = name_pb,
+            extensions = ["pyi"],
+        )
+        pyi_srcs = [name_pyi_files]
+
     # For other code to import generated code with prefix_path if it's given
     output_mode = kwargs.get("output_mode", "PREFIXED")
     if output_mode == "PREFIXED":
@@ -42,6 +53,7 @@ def python_proto_library(name, generate_pyi = False, **kwargs):
         deps = PROTO_DEPS + kwargs.get("deps", []),
         data = kwargs.get("data", []),  # See https://github.com/rules-proto-grpc/rules_proto_grpc/issues/257 for use case
         imports = imports,
+        pyi_srcs = pyi_srcs,
         **{
             k: v
             for (k, v) in kwargs.items()

--- a/test_workspaces/python3_grpc/BUILD.bazel
+++ b/test_workspaces/python3_grpc/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_proto_grpc_python//:defs.bzl", "python_grpc_library")
 load("@rules_python//python:defs.bzl", "py_test")
+load(":has_direct_pyi_files_test.bzl", "has_direct_pyi_files_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -27,4 +28,18 @@ py_test(
     main = "main.py",
     python_version = "PY3",
     deps = ["py_lib"],
+)
+
+# Regression test for generate_pyi=True
+# This verifies that .pyi files are properly added to PyInfo.direct_pyi_files
+python_grpc_library(
+    name = "py_lib_with_pyi",
+    protos = ["proto_lib"],
+    generate_pyi = True,
+    python_version = "PY3",
+)
+
+has_direct_pyi_files_test(
+    name = "test_pyi_in_pyinfo",
+    target_under_test = ":py_lib_with_pyi",
 )

--- a/test_workspaces/python3_grpc/MODULE.bazel
+++ b/test_workspaces/python3_grpc/MODULE.bazel
@@ -1,3 +1,4 @@
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
 bazel_dep(name = "rules_python", version = "1.9.0")

--- a/test_workspaces/python3_grpc/has_direct_pyi_files_test.bzl
+++ b/test_workspaces/python3_grpc/has_direct_pyi_files_test.bzl
@@ -1,0 +1,37 @@
+"""Test rule that verifies .pyi files are properly added to PyInfo.
+
+This is a regression test for the fix that ensures python_proto_library with
+generate_pyi=True properly populates PyInfo.direct_pyi_files, which is required
+for type checkers and linters to resolve imports from generated protobuf modules.
+"""
+
+load('@bazel_skylib//lib:unittest.bzl', 'analysistest', 'asserts')
+
+def _has_direct_pyi_files_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    # Ensure the target provides PyInfo
+    asserts.true(env, PyInfo in target, 'target does not provide PyInfo')
+
+    pyinfo = target[PyInfo]
+
+    # Ensure the target PyInfo has direct_pyi_files attributes
+    asserts.true(
+        env,
+        hasattr(pyinfo, 'direct_pyi_files'),
+        'PyInfo does not have direct_pyi_files',
+    )
+
+    # Ensure the PyInfo.direct_pyi_files has at least one file
+    asserts.true(
+        env,
+        len(pyinfo.direct_pyi_files.to_list()) > 0,
+        'direct_pyi_files is empty',
+    )
+
+    return analysistest.end(env)
+
+has_direct_pyi_files_test = analysistest.make(
+    _has_direct_pyi_files_test_impl,
+)


### PR DESCRIPTION
This pull request:
  - Add support for propagating generated `.pyi` stub files to `PyInfo.direct_pyi_files`
  - Ensures type checkers and linters can properly resolve imports from generated protobuf modules when `generate_pyi=True` is set
  - Add regression test to verify `PyInfo.direct_pyi_files` is populated correctly