### PR TITLE
Add Python 3.14 support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,7 +117,7 @@ local_path_override(
     path = "modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/docs/lang/python.rst
+++ b/docs/lang/python.rst
@@ -37,7 +37,7 @@ The Python module can be installed by adding the following lines to your MODULE.
 .. code-block:: python
 
    bazel_dep(name = "rules_proto_grpc_python", version = "<version number here>")
-   bazel_dep(name = "rules_python", version = "1.9.0")
+   bazel_dep(name = "rules_python", version = "2.1.0")
    
    python = use_extension("@rules_python//python/extensions:python.bzl", "python")
    python.toolchain(python_version = "3.11")

--- a/examples/python/python_grpc_compile/MODULE.bazel
+++ b/examples/python/python_grpc_compile/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/examples/python/python_grpc_library/MODULE.bazel
+++ b/examples/python/python_grpc_library/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/examples/python/python_grpclib_compile/MODULE.bazel
+++ b/examples/python/python_grpclib_compile/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/examples/python/python_grpclib_library/MODULE.bazel
+++ b/examples/python/python_grpclib_library/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/examples/python/python_proto_compile/MODULE.bazel
+++ b/examples/python/python_proto_compile/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/examples/python/python_proto_library/MODULE.bazel
+++ b/examples/python/python_proto_library/MODULE.bazel
@@ -17,7 +17,7 @@ local_path_override(
     path = "../../../modules/python",
 )
 
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")

--- a/modules/python/MODULE.bazel
+++ b/modules/python/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 bazel_dep(name = "grpc", version = "1.78.0")
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 PYTHON_VERSIONS = [
     "3.9",
@@ -15,6 +15,7 @@ PYTHON_VERSIONS = [
     "3.11",
     "3.12",
     "3.13",
+    "3.14",
 ]
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/test_workspaces/absolute_strip_import_prefix/MODULE.bazel
+++ b/test_workspaces/absolute_strip_import_prefix/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/combined_strip_and_add_prefix/MODULE.bazel
+++ b/test_workspaces/combined_strip_and_add_prefix/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/empty_output_directory/MODULE.bazel
+++ b/test_workspaces/empty_output_directory/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "grpc", version = "1.78.0")
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/exclusions/MODULE.bazel
+++ b/test_workspaces/exclusions/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/generated_proto/MODULE.bazel
+++ b/test_workspaces/generated_proto/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "another_workspace", version = "0.0.0")
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "another_workspace",

--- a/test_workspaces/generated_proto/another_workspace/MODULE.bazel
+++ b/test_workspaces/generated_proto/another_workspace/MODULE.bazel
@@ -2,7 +2,7 @@ module(name = "another_workspace")
 
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/import_prefix/MODULE.bazel
+++ b/test_workspaces/import_prefix/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/nested_output_directory/MODULE.bazel
+++ b/test_workspaces/nested_output_directory/MODULE.bazel
@@ -2,7 +2,7 @@ bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc", version = "0.0.0.rpg.version.placeholder")
 bazel_dep(name = "rules_proto_grpc_csharp", version = "0.0.0.rpg.version.placeholder")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/objc_capitalisation/MODULE.bazel
+++ b/test_workspaces/objc_capitalisation/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_proto_grpc_objc", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/prefix_path/MODULE.bazel
+++ b/test_workspaces/prefix_path/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/python3_grpc/MODULE.bazel
+++ b/test_workspaces/python3_grpc/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/python_dashes/MODULE.bazel
+++ b/test_workspaces/python_dashes/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/python_deps/MODULE.bazel
+++ b/test_workspaces/python_deps/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/python_dots/MODULE.bazel
+++ b/test_workspaces/python_dots/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/relative_strip_import_prefix/MODULE.bazel
+++ b/test_workspaces/relative_strip_import_prefix/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/test_workspaces/shared_proto/MODULE.bazel
+++ b/test_workspaces/shared_proto/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "protobuf", version = "34.0.bcr.1")
 bazel_dep(name = "rules_proto_grpc_python", version = "0.0.0.rpg.version.placeholder")
-bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_python", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_proto_grpc",

--- a/tools/rulegen/python.go
+++ b/tools/rulegen/python.go
@@ -123,7 +123,7 @@ GRPCLIB_DEPS = [
     Label("@protobuf//:protobuf_python"),
 ]`)
 
-var pythonModuleSuffixLines = `bazel_dep(name = "rules_python", version = "1.9.0")
+var pythonModuleSuffixLines = `bazel_dep(name = "rules_python", version = "2.1.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.11")`


### PR DESCRIPTION
Registers a Python 3.14 toolchain in the python module and bumps rules_python 1.9.0 to 2.1.0, the first release that ships 3.14. Output files are regenerated with tools/rulegen.

Note on CI: the failing BuildKite run is not caused by this change. CI is currently red repo-wide (master and every open PR, including trivial ones like #653 and #654), because the dependency stack is not yet compatible with the Bazel version BuildKite runs:

* Python and C++: grpc's third_party/address_sorting/address_sorting.bzl calls native.cc_library, which has been removed in the Bazel version CI uses (Error in fail: This rule has been removed from Bazel).
* Java and "Build & Test All": no such target '@@rules_jvm_external++maven+maven//:io_grpc_grpc_stub' (looks related to the in-progress #648 maven lock work).
* On a clean build, rules_python resolution also fails with key "3.14.0b2" not found in dictionary, because grpc 1.78.0 pins an old rules_python whose minor mapping still points 3.14 at the withdrawn 3.14.0b2 preview.

This PR is intentionally minimal so it can merge once the dependency and Bazel compatibility work already underway lands. The 3.14 support itself is verified locally: with a Bazel 8 toolchain and a grpc bump to clear the 3.14.0b2 mapping, examples/python/python_grpclib_library builds end to end under --@rules_python//python/config_settings:python_version=3.14, pulling the cp314 wheels.
